### PR TITLE
fix: fix rounding error by replacing parseInt with parseFloat

### DIFF
--- a/src/components/visualization/BarChart.tsx
+++ b/src/components/visualization/BarChart.tsx
@@ -49,7 +49,7 @@ function getMaxAndMinYValue(records: DataRecord, yAxis: string) {
       .filter(([key, _]) => key === yAxis)
       .map((entry) => entry[1]);
     for (const value of valueArray) {
-      const parsedValue = Number.parseInt(value, 10);
+      const parsedValue = Number.parseFloat(value);
       if (parsedValue > maxValue) {
         maxValue = parsedValue;
       } else if (parsedValue < minValue) {


### PR DESCRIPTION
Fixes a small bug in the bar chart that led to floating point numbers being wrongfully converted to integers, therefore losing information

https://deploy-preview-53--open-data-dashboard.netlify.app/resource/7?search=%7B"all-entries"%3A"Nordwest"%7D