### PR TITLE
feat: Implement option for setting default filters in configuration file

### DIFF
--- a/__tests__/components/chartTableFilterHeader.test.tsx
+++ b/__tests__/components/chartTableFilterHeader.test.tsx
@@ -5,8 +5,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { filterAllEntries, filterAllEntriesInvalid } from '../data/dataFilters';
 import { fireEvent, render, screen } from '@testing-library/react';
+
 import AccordionContext from 'react-bootstrap/AccordionContext';
 import { ChartTableFilterHeader } from '@/components/visualization/chart-table-filter/ChartTableFilterHeader';
+import { Filter } from '@/schema';
 import { NextIntlClientProvider } from 'next-intl';
 import messages from '@/messages/en.json';
 import { useAccordionButton } from 'react-bootstrap/AccordionButton';
@@ -26,10 +28,7 @@ describe('component ChartTableFilterHeader', () => {
   const mockOnChange = jest.fn();
   const mockUseAccordionButton = useAccordionButton as jest.Mock;
 
-  const renderComponent = (
-    activeEventKey?: string,
-    filters: Record<string, string | { min?: string | undefined; max?: string | undefined }> = {},
-  ) => {
+  const renderComponent = (activeEventKey?: string, filters: Record<string, Filter> = {}) => {
     render(
       <NextIntlClientProvider locale="en" messages={messages}>
         <AccordionContext.Provider value={{ activeEventKey }}>

--- a/data-source.config.yml
+++ b/data-source.config.yml
@@ -1,17 +1,20 @@
 appearance:
-    theme: 'karlsruhe'
+    theme: "karlsruhe"
 resources:
     - id: "1"
       source: https://mocki.io/v1/1442bc5a-869f-4398-96a9-c5c50fc3b1a3
       #   source: https://transparenz.karlsruhe.de/datastore/dump/71ef348f-0f5b-46a0-8250-e87aae9f91bd?format=json
       type: JSON
       name: Wohnberechtigte Bevölkerung
-      tag: asas
       description: dadad
       renameFields:
           mannlich (%): Männlich (%)
           weiblich (%): Weiblich (%)
       skipFieldsRegEx: ^_id$
+      defaultFilters:
+          Jahr:
+              min: 2009
+              max: 2009
       visualizations:
           barChart:
               axisPairs:
@@ -70,10 +73,10 @@ resources:
       visualizations:
           barChart:
               axisPairs:
-                - xAxis: Partei/politische Vereinigung
-                  yAxis: Stimmen
-                - xAxis: Parteiname
-                  yAxis: "%"
+                  - xAxis: Partei/politische Vereinigung
+                    yAxis: Stimmen
+                  - xAxis: Parteiname
+                    yAxis: "%"
     - id: "7"
       source: https://mocki.io/v1/iprobablydontexist
       # source: https://transparenz.karlsruhe.de/datastore/dump/iprobablydontexist?format=json

--- a/src/components/visualization/chart-table-filter/ChartTableFilter.tsx
+++ b/src/components/visualization/chart-table-filter/ChartTableFilter.tsx
@@ -1,12 +1,13 @@
+import { Filter, TransformableResource } from '@/schema';
 import { useEffect, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
 import Accordion from 'react-bootstrap/Accordion';
 import { ChartTableFilterBody } from './ChartTableFilterBody';
 import { ChartTableFilterHeader } from './ChartTableFilterHeader';
 import CurrentFilters from './CurrentFilters';
 import { DataRecord } from '@/types/visualization';
 import LocaleSwitcher from '@/components/LocaleSwitcher';
-import { TransformableResource } from '@/schema';
 import { filterData } from '@/filter';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -22,21 +23,27 @@ export default function ChartTableFilter({
 }) {
   const searchParams = useSearchParams();
   const [filters, setFilters] = useState(
-    JSON.parse(searchParams.get('search') ?? '{}') as Record<string, string | { min?: string; max?: string }>,
+    searchParams.get('search')
+      ? (JSON.parse(searchParams.get('search') ?? '{}') as Record<string, Filter>)
+      : resource.defaultFilters ?? {},
   );
   const pathname = usePathname();
   const router = useRouter();
 
   useEffect(() => {
-    // use query parameters on initial render
+    // use query parameters or default filter on initial render
     filter();
+    // if query parameters are not set, set them to the value of defaultFilters
+    if (!searchParams.get('search') && resource.defaultFilters) {
+      setParams(resource.defaultFilters);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  function onChange(key: string, value: string | { min?: string; max?: string }) {
+  function onChange(key: string, value: Filter) {
     let updatedFilters;
     if (value) {
-      updatedFilters = { ...filters } as Record<string, string | { min?: string; max?: string }>;
+      updatedFilters = { ...filters } as Record<string, Filter>;
       updatedFilters[key] = value;
     } else {
       updatedFilters = Object.assign(
@@ -51,11 +58,11 @@ export default function ChartTableFilter({
     setParams(updatedFilters);
   }
 
-  function filter(updatedFilters: Record<string, string | { min?: string; max?: string }> = filters) {
+  function filter(updatedFilters: Record<string, Filter> = filters) {
     onFilter(filterData(data, updatedFilters));
   }
 
-  const setParams = useDebouncedCallback((updatedFilters: Record<string, string | { min?: string; max?: string }>) => {
+  const setParams = useDebouncedCallback((updatedFilters: Record<string, Filter>) => {
     const params = new URLSearchParams(searchParams);
     if (Object.keys(updatedFilters).length === 0) {
       params.delete('search');

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -64,7 +64,21 @@ export const TransformableResourceSchema = BaseResourceSchema.extend({
         })
         .strict()
         .default({ table: {} }),
-}).strict();
+})
+    .strict()
+    .refine(
+        (data) => {
+            if (data.skipFieldsRegEx && data.renameFields) {
+                const regex = new RegExp(data.skipFieldsRegEx, 'u');
+                return !Object.keys(data.renameFields).some((key) => regex.test(key));
+            }
+            return true;
+        },
+        {
+            message: 'skipFieldsRegEx should not match any keys in renameFields',
+            path: ['skipFieldsRegEx'],
+        },
+    );
 
 export const ResourceSchema = z.union([GeoJSONResourceSchema, TransformableResourceSchema, EmbeddedResourceSchema]);
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -34,10 +34,24 @@ const AxisPairSchema = z
     })
     .strict();
 
+const DefaultFilterSchema = z.union([
+    z.string(),
+    z
+        .object({
+            min: z.number().transform(String).optional(),
+            max: z.number().transform(String).optional(),
+        })
+        .strict()
+        .refine((data) => data.min !== undefined || data.max !== undefined, {
+            message: "At least one of 'min' or 'max' must be defined",
+        }),
+]);
+
 export const TransformableResourceSchema = BaseResourceSchema.extend({
     type: z.union([z.literal('JSON'), z.literal('CSV')]),
     skipFieldsRegEx: z.string().optional(),
     renameFields: z.record(z.string()).optional(),
+    defaultFilters: z.record(z.string(), DefaultFilterSchema).optional(),
     visualizations: z
         .object({
             barChart: z
@@ -72,3 +86,4 @@ export type AxisPair = z.infer<typeof AxisPairSchema>;
 export type TransformableResource = z.infer<typeof TransformableResourceSchema>;
 export type Resource = z.infer<typeof ResourceSchema>;
 export type Configuration = z.infer<typeof ConfigurationSchema>;
+export type Filter = z.infer<typeof DefaultFilterSchema>;


### PR DESCRIPTION
[ODDSK-182](https://h-ka-team-rdqzrlfpomci.atlassian.net/browse/ODDSK-182).

Working example: https://deploy-preview-87--open-data-dashboard.netlify.app/en/resource/1.

Expected behaviour:
* Upon initial loading, the filter `Jahr = 2009` should be applied to the data.
* If you call a resource that has a default filter configured without your own `search` query param, the query param should get set to the values of the default filter.
* If you call a resource with your own query params, they should stay untouched.