### PR TITLE
feat: Implement homepage

### DIFF
--- a/.lighthouserc.yml
+++ b/.lighthouserc.yml
@@ -4,6 +4,7 @@ ci:
         startServerCommand: npm run start
         startServerReadyPattern: Ready in
         url:
+            - http://localhost:3000/en/home
             - http://localhost:3000/en/view/Wohnberechtigte-Bevölkerung-1
             - http://localhost:3000/en/view/Points-of-Interest-Kinos-3
         numberOfRuns: 1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.language": "en,de-de",
     "cSpell.words": [
+        "deepmerge",
         "dracula",
         "karlsruhe",
         "minisearch",

--- a/__tests__/config-validation/configurationMatcher.ts
+++ b/__tests__/config-validation/configurationMatcher.ts
@@ -6,6 +6,7 @@ import {
     appearanceSchema,
     categoriesSchema,
     configurationSchema,
+    dashboardsSchema,
     embeddedResourceSchema,
     geoJSONResourceSchema,
     jsonResourceSchema,
@@ -58,6 +59,7 @@ function toBeValidConfiguration(configuration: Configuration) {
                   })
                   .filter((error) => error !== undefined) as string[]);
     const categoriesError = parseConfigurationSection(configuration.categories, categoriesSchema);
+    const dashboardsError = parseConfigurationSection(configuration.dashboards, dashboardsSchema);
 
     const errorMessages = ['The configuration contains errors.'];
     errorMessages.push(`Summary: ${fromError(parsedConfiguration.error).toString()}\n\nSee the details below:\n`);
@@ -70,6 +72,9 @@ function toBeValidConfiguration(configuration: Configuration) {
     }
     if (categoriesError) {
         errorMessages.push(`Categories Error: ${categoriesError}`);
+    }
+    if (dashboardsError) {
+        errorMessages.push(`Dashboards Error: ${dashboardsError}`);
     }
 
     const message = errorMessages.join('\n');
@@ -88,7 +93,8 @@ function parseConfigurationSection(
         | typeof jsonResourceSchema
         | typeof geoJSONResourceSchema
         | typeof appearanceSchema
-        | typeof categoriesSchema,
+        | typeof categoriesSchema
+        | typeof dashboardsSchema,
 ) {
     const parsedSection = schema.safeParse(section);
     return parsedSection.success ? undefined : fromError(parsedSection.error).toString();

--- a/__tests__/config-validation/configurationMatcher.ts
+++ b/__tests__/config-validation/configurationMatcher.ts
@@ -43,7 +43,8 @@ function toBeValidConfiguration(configuration: Configuration) {
                               resourceError = parseConfigurationSection(resource, geoJSONResourceSchema);
                               break;
                           }
-                          case 'Embedded': {
+                          case 'HTML':
+                          case 'PDF': {
                               resourceError = parseConfigurationSection(resource, embeddedResourceSchema);
                               break;
                           }

--- a/__tests__/data/resources.ts
+++ b/__tests__/data/resources.ts
@@ -6,7 +6,7 @@ export const embeddedResource: EmbeddedResource = {
     id: '1',
     source: mockSource,
     name: 'Embedded Resource',
-    type: 'Embedded',
+    type: 'PDF',
 };
 
 export const jsonResource: JSONResource = {

--- a/config/data-source.app.config.yml
+++ b/config/data-source.app.config.yml
@@ -78,18 +78,9 @@ resources:
                   - xAxis: Parteiname
                     yAxis: "%"
     - id: "7"
-      source: https://mocki.io/v1/iprobablydontexist
-      # source: https://transparenz.karlsruhe.de/datastore/dump/iprobablydontexist?format=json
-      type: JSON
-      name: Not Found
-      visualizations:
-          table: {}
-    - id: "8"
-      source: https://mocki.io/v1/5e610643-2531-4aba-9191-aa1c2524e96e
-      type: JSON
-      name: Empty
-      visualizations:
-          table: {}
+      source: https://web6.karlsruhe.de/Stadtentwicklung/statistik/mietspiegelrechner/mietspiegel-2023.html
+      type: HTML
+      name: Mietspiegelrechner
 categories:
     - name: Mobilität
       icon: train-front-fill
@@ -100,8 +91,9 @@ dashboards:
       name: Homepage
       icon: house-door-fill
       contents:
-          - kind: EXTERNAL
+          - type: EXTERNAL
             source: https://www.wetter.de/widget/heute/u0tyz1rj/false/
+            name: Weather
     - id: "1"
       name: Bevölkerung
       icon: people-fill

--- a/config/data-source.app.config.yml
+++ b/config/data-source.app.config.yml
@@ -27,7 +27,7 @@ resources:
           table: {}
     - id: "2"
       source: https://web6.karlsruhe.de/Stadtentwicklung/statistik/pdf/mietspiegel/karlsruher-mietspiegel-2023.pdf
-      type: Embedded
+      type: PDF
       name: Karlsruher Mietspiegel 2023
     - id: "3"
       source: https://mocki.io/v1/56ffb4b7-49d5-4763-98ec-db1a67feb0a5

--- a/config/data-source.app.config.yml
+++ b/config/data-source.app.config.yml
@@ -99,7 +99,7 @@ dashboards:
     - id: homepage
       name: Homepage
       icon: house-door-fill
-      content:
+      contents:
           - kind: EXTERNAL
             source: https://www.wetter.de/widget/heute/u0tyz1rj/false/
     - id: "1"

--- a/config/data-source.app.config.yml
+++ b/config/data-source.app.config.yml
@@ -95,3 +95,19 @@ categories:
       icon: train-front-fill
     - name: Category 2
     - name: Category 3
+dashboards:
+    - id: homepage
+      name: Homepage
+      icon: house-door-fill
+      content:
+          - kind: EXTERNAL
+            source: https://www.wetter.de/widget/heute/u0tyz1rj/false/
+    - id: "1"
+      name: Bevölkerung
+      icon: people-fill
+    - id: "2"
+      name: Bildung
+    - id: "3"
+      name: Mobilität
+      icon: train-front-fill
+

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,13 @@ const withNextIntl = createNextIntlPlugin();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     reactStrictMode: true,
+    images: {
+        remotePatterns: [
+            {
+                hostname: 'rp.baden-wuerttemberg.de',
+            },
+        ],
+    },
 };
 
 export default withNextIntl(nextConfig);

--- a/src/app/[locale]/(embedded)/resource/[resourceId]/page.tsx
+++ b/src/app/[locale]/(embedded)/resource/[resourceId]/page.tsx
@@ -29,7 +29,7 @@ export default async function Page({ params: { resourceId } }: { params: { resou
   }
 
   if (resource.type === 'Embedded') {
-    return <EmbeddedViewer resource={parsedResource.data} />;
+    return <EmbeddedViewer resource={parsedResource.data} className="d-flex h-100" />;
   }
   return <Visualization resource={parsedResource.data as JSONResource | GeoJSONResource} />;
 }

--- a/src/app/[locale]/(embedded)/resource/[resourceId]/page.tsx
+++ b/src/app/[locale]/(embedded)/resource/[resourceId]/page.tsx
@@ -28,7 +28,7 @@ export default async function Page({ params: { resourceId } }: { params: { resou
     );
   }
 
-  if (resource.type === 'Embedded') {
+  if (resource.type === 'HTML' || resource.type === 'PDF') {
     return <EmbeddedViewer resource={parsedResource.data} className="d-flex h-100" />;
   }
   return <Visualization resource={parsedResource.data as JSONResource | GeoJSONResource} />;

--- a/src/app/[locale]/(main)/home/page.tsx
+++ b/src/app/[locale]/(main)/home/page.tsx
@@ -42,7 +42,7 @@ export default async function Home() {
             source: 'https://www.wetter.de/widget/heute/u0tyz1rj/false/',
             id: '12',
             name: 'Wetter',
-            type: 'Embedded',
+            type: 'HTML',
           }}
         />
       </div>

--- a/src/app/[locale]/(main)/home/page.tsx
+++ b/src/app/[locale]/(main)/home/page.tsx
@@ -1,4 +1,4 @@
-import EmbeddedViewer from '@/components/visualization/EmbeddedViewer';
+import DashboardContent from '@/components/dashboard/DashboardContent';
 import ErrorComponent from '@/components/error-handling/ErrorComponent';
 import Image from 'next/image';
 import Search from '@/components/search/Search';
@@ -35,26 +35,7 @@ export default async function Home() {
           style={{ bottom: '10%' }}
         />
       </div>
-      <div className="d-flex flex-wrap justify-content-center mt-3">
-        {homepage.content?.map((cont, index) => {
-          if (cont.kind === 'EXTERNAL') {
-            return (
-              <EmbeddedViewer
-                key={index}
-                // TODO: Properly handle height
-                height={260}
-                resource={{
-                  source: cont.source,
-                  id: 'external',
-                  name: 'external',
-                  type: 'HTML',
-                }}
-              />
-            );
-          }
-          //   TODO: Handle internal content
-        })}
-      </div>
+      <DashboardContent dashboard={homepage} />
     </div>
   );
 }

--- a/src/app/[locale]/(main)/home/page.tsx
+++ b/src/app/[locale]/(main)/home/page.tsx
@@ -14,6 +14,7 @@ export default async function Home() {
   if (!parsedConfiguration.success) {
     return <ErrorComponent type="configurationInvalid" error={JSON.stringify(parsedConfiguration.error)} />;
   }
+  const [homepage] = parsedConfiguration.data.dashboards;
 
   return (
     <div className="d-flex flex-column flex-grow-1">
@@ -34,17 +35,25 @@ export default async function Home() {
           style={{ bottom: '10%' }}
         />
       </div>
-      {/* TODO: Determine the actual content of the homepage preview and make it configurable */}
       <div className="d-flex flex-wrap justify-content-center mt-3">
-        <EmbeddedViewer
-          height={260}
-          resource={{
-            source: 'https://www.wetter.de/widget/heute/u0tyz1rj/false/',
-            id: '12',
-            name: 'Wetter',
-            type: 'HTML',
-          }}
-        />
+        {homepage.content?.map((cont, index) => {
+          if (cont.kind === 'EXTERNAL') {
+            return (
+              <EmbeddedViewer
+                key={index}
+                // TODO: Properly handle height
+                height={260}
+                resource={{
+                  source: cont.source,
+                  id: 'external',
+                  name: 'external',
+                  type: 'HTML',
+                }}
+              />
+            );
+          }
+          //   TODO: Handle internal content
+        })}
       </div>
     </div>
   );

--- a/src/app/[locale]/(main)/home/page.tsx
+++ b/src/app/[locale]/(main)/home/page.tsx
@@ -1,3 +1,36 @@
-export default function Home() {
-  return <></>;
+import ErrorComponent from '@/components/error-handling/ErrorComponent';
+import Image from 'next/image';
+import Search from '@/components/search/Search';
+import { configurationSchema } from '@/schemas/configuration-schema';
+import { getConfiguration } from '@/configuration';
+
+export default async function Home() {
+  const configuration = await getConfiguration();
+  if (!configuration.success) {
+    return <ErrorComponent type="configurationNotLoaded" error={String(configuration.error)} />;
+  }
+  const parsedConfiguration = configurationSchema.safeParse(configuration.data);
+  if (!parsedConfiguration.success) {
+    return <ErrorComponent type="configurationInvalid" error={JSON.stringify(parsedConfiguration.error)} />;
+  }
+
+  return (
+    <div className="d-flex flex-column flex-grow-1">
+      <div className="position-relative w-100" style={{ height: '500px' }}>
+        {/* TODO: Acquire licensed picture or add attribution */}
+        {/* Source: https://rp.baden-wuerttemberg.de/rps/presse/artikel/bau-und-kunstdenkmalpflege-schloesser-und-gaerten-in-baden-wuerttemberg/ */}
+        <Image
+          src="https://rp.baden-wuerttemberg.de/fileadmin/_processed_/8/0/csm_AdobeStock_516119904_Schloss_Karlsruhe_Markus_Mainka_7fd664f58b.jpeg"
+          alt="Kalrsruher Schloss"
+          objectFit="cover"
+          fill
+        />
+        <Search
+          configuration={parsedConfiguration.data}
+          className="position-absolute w-100 p-5"
+          style={{ bottom: '10%' }}
+        />
+      </div>
+    </div>
+  );
 }

--- a/src/app/[locale]/(main)/home/page.tsx
+++ b/src/app/[locale]/(main)/home/page.tsx
@@ -1,3 +1,4 @@
+import EmbeddedViewer from '@/components/visualization/EmbeddedViewer';
 import ErrorComponent from '@/components/error-handling/ErrorComponent';
 import Image from 'next/image';
 import Search from '@/components/search/Search';
@@ -20,15 +21,29 @@ export default async function Home() {
         {/* TODO: Acquire licensed picture or add attribution */}
         {/* Source: https://rp.baden-wuerttemberg.de/rps/presse/artikel/bau-und-kunstdenkmalpflege-schloesser-und-gaerten-in-baden-wuerttemberg/ */}
         <Image
+          className="object-fit-cover"
           src="https://rp.baden-wuerttemberg.de/fileadmin/_processed_/8/0/csm_AdobeStock_516119904_Schloss_Karlsruhe_Markus_Mainka_7fd664f58b.jpeg"
-          alt="Kalrsruher Schloss"
-          objectFit="cover"
+          alt="Karlsruher Schloss"
+          priority
           fill
+          sizes="1700px"
         />
         <Search
           configuration={parsedConfiguration.data}
           className="position-absolute w-100 p-5"
           style={{ bottom: '10%' }}
+        />
+      </div>
+      {/* TODO: Determine the actual content of the homepage preview and make it configurable */}
+      <div className="d-flex flex-wrap justify-content-center mt-3">
+        <EmbeddedViewer
+          height={260}
+          resource={{
+            source: 'https://www.wetter.de/widget/heute/u0tyz1rj/false/',
+            id: '12',
+            name: 'Wetter',
+            type: 'Embedded',
+          }}
         />
       </div>
     </div>

--- a/src/app/[locale]/(main)/home/page.tsx
+++ b/src/app/[locale]/(main)/home/page.tsx
@@ -31,8 +31,9 @@ export default async function Home() {
         />
         <Search
           configuration={parsedConfiguration.data}
-          className="position-absolute w-100 p-5"
-          style={{ bottom: '10%' }}
+          id="homepage-search"
+          className="position-absolute w-50 start-50"
+          style={{ bottom: '20%', transform: 'translateX(-50%)' }}
         />
       </div>
       <DashboardContent dashboard={homepage} />

--- a/src/app/[locale]/(main)/layout.tsx
+++ b/src/app/[locale]/(main)/layout.tsx
@@ -23,7 +23,7 @@ export default async function RootLayout({
     <div style={{ background: colorLight }}>
       <NavigationProvider>
         <Header configuration={parsedConfiguration.data} />
-        <div className="container-lg d-flex bg-white">
+        <div className="container-lg d-flex bg-white p-0">
           <Navigation configuration={parsedConfiguration.data} />
           {children}
         </div>

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -5,7 +5,7 @@ export default function DashboardContent({ dashboard }: { dashboard: Dashboard }
   return (
     <div className="d-flex flex-wrap justify-content-center mt-3">
       {dashboard.contents?.map((content, index) => {
-        if (content.kind === 'EXTERNAL') {
+        if (content.type === 'EXTERNAL') {
           return (
             <EmbeddedViewer
               key={index}
@@ -14,7 +14,7 @@ export default function DashboardContent({ dashboard }: { dashboard: Dashboard }
               resource={{
                 source: content.source,
                 id: 'external',
-                name: 'external',
+                name: content.name,
                 type: 'HTML',
               }}
             />

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -4,15 +4,15 @@ import EmbeddedViewer from '../visualization/EmbeddedViewer';
 export default function DashboardContent({ dashboard }: { dashboard: Dashboard }) {
   return (
     <div className="d-flex flex-wrap justify-content-center mt-3">
-      {dashboard.content?.map((cont, index) => {
-        if (cont.kind === 'EXTERNAL') {
+      {dashboard.contents?.map((content, index) => {
+        if (content.kind === 'EXTERNAL') {
           return (
             <EmbeddedViewer
               key={index}
               // TODO: Properly handle height
               height={260}
               resource={{
-                source: cont.source,
+                source: content.source,
                 id: 'external',
                 name: 'external',
                 type: 'HTML',

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -1,0 +1,27 @@
+import { Dashboard } from '@/schemas/configuration-schema';
+import EmbeddedViewer from '../visualization/EmbeddedViewer';
+
+export default function DashboardContent({ dashboard }: { dashboard: Dashboard }) {
+  return (
+    <div className="d-flex flex-wrap justify-content-center mt-3">
+      {dashboard.content?.map((cont, index) => {
+        if (cont.kind === 'EXTERNAL') {
+          return (
+            <EmbeddedViewer
+              key={index}
+              // TODO: Properly handle height
+              height={260}
+              resource={{
+                source: cont.source,
+                id: 'external',
+                name: 'external',
+                type: 'HTML',
+              }}
+            />
+          );
+        }
+        //   TODO: Handle internal content
+      })}
+    </div>
+  );
+}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -18,7 +18,7 @@ export default function Header({ configuration }: { configuration: Configuration
   return (
     <div className="bg-white py-3">
       <div className="container-lg">
-        <div className="d-flex justify-content-center align-items-center m-2">
+        <div className="d-flex justify-content-between align-items-center m-2">
           <button
             className="d-block d-lg-none btn btn-secondary border-0 fs-2"
             onClick={() => {
@@ -28,10 +28,12 @@ export default function Header({ configuration }: { configuration: Configuration
           >
             <i className="bi bi-list" />
           </button>
-          <div className="flex-fill align-content-center p-2 ps-4 fs-5 fs-lg-2 text-nowrap">{t('title')}</div>
-          {showSearchbar && <Search configuration={configuration} className="d-none d-md-block flex-fill p-2 m-auto" />}
-          <div className="d-none d-md-block flex-fill align-content-center p-2">
-            <LocaleSwitcher />
+          <div className="fs-5 fs-lg-2 text-nowrap">{t('title')}</div>
+          <div className="d-flex flex-fill mx-lg-3 mx-xl-5">
+            {showSearchbar && (
+              <Search configuration={configuration} className="d-none d-md-block flex-fill p-2 m-auto" />
+            )}
+            <LocaleSwitcher className="d-none d-md-block p-2" />
           </div>
           <Image
             className="d-block d-lg-none"

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -24,6 +24,7 @@ export default function Header({ configuration }: { configuration: Configuration
             onClick={() => {
               setShow(!show);
             }}
+            name="Navigation"
           >
             <i className="bi bi-list" />
           </button>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -41,7 +41,11 @@ export default function Header({ configuration }: { configuration: Configuration
           </Link>
           <div className="d-flex flex-fill mx-lg-3 mx-xl-5">
             {showSearchbar && (
-              <Search configuration={configuration} className="d-none d-md-block flex-fill p-2 m-auto" />
+              <Search
+                configuration={configuration}
+                id="desktop-search"
+                className="d-none d-md-block flex-fill p-2 m-auto"
+              />
             )}
             <LocaleSwitcher className="d-none d-md-block p-2" />
           </div>
@@ -58,6 +62,7 @@ export default function Header({ configuration }: { configuration: Configuration
         {showSearchbar && (
           <Search
             configuration={configuration}
+            id="mobile-search"
             className="d-block d-md-none flex-fill m-2"
             style={{ maxWidth: '70vw' }}
           />

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -7,9 +7,14 @@ import LogoKarlsruhe from '../../public/Logo_Digital_Karlsruhe-rechts_rgb.svg';
 import LogoKarlsruheSmall from '../../public/Logo_Digital_Karlsruhe-rechts_rgb_small.svg';
 import Search from '../search/Search';
 import { StaticImport } from 'next/dist/shared/lib/get-img-props';
-import { usePathname } from 'next/navigation';
+import { createSharedPathnamesNavigation } from 'next-intl/navigation';
+import { locales } from '@/locales';
 import { useShowNavigation } from '../navigation/NavigationProvider';
 import { useTranslations } from 'next-intl';
+
+const { Link, usePathname } = createSharedPathnamesNavigation({
+  locales: [...locales.values()],
+});
 
 export default function Header({ configuration }: { configuration: Configuration }) {
   const { show, setShow } = useShowNavigation();
@@ -28,7 +33,12 @@ export default function Header({ configuration }: { configuration: Configuration
           >
             <i className="bi bi-list" />
           </button>
-          <div className="fs-5 fs-lg-2 text-nowrap">{t('title')}</div>
+          <Link
+            href="/home"
+            className="link link-secondary link-underline-opacity-0 text-black fs-5 fs-lg-2 text-nowrap"
+          >
+            {t('title')}
+          </Link>
           <div className="d-flex flex-fill mx-lg-3 mx-xl-5">
             {showSearchbar && (
               <Search configuration={configuration} className="d-none d-md-block flex-fill p-2 m-auto" />

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -18,9 +18,9 @@ export default function Header({ configuration }: { configuration: Configuration
   return (
     <div className="bg-white py-3">
       <div className="container-lg">
-        <div className="d-flex justify-content-center m-2">
+        <div className="d-flex justify-content-center align-items-center m-2">
           <button
-            className="d-block d-lg-none btn btn-secondary"
+            className="d-block d-lg-none btn btn-secondary border-0 fs-2"
             onClick={() => {
               setShow(!show);
             }}
@@ -33,17 +33,12 @@ export default function Header({ configuration }: { configuration: Configuration
             <LocaleSwitcher />
           </div>
           <Image
-            className="d-block d-lg-none justify-content-end"
+            className="d-block d-lg-none"
             src={LogoKarlsruheSmall as StaticImport}
             alt={'LogoKarlsruheSmall'}
             height={50}
           />
-          <Image
-            className="d-none d-lg-block justify-content-end"
-            src={LogoKarlsruhe as StaticImport}
-            alt={'LogoKarlsruhe'}
-            height={60}
-          />
+          <Image className="d-none d-lg-block" src={LogoKarlsruhe as StaticImport} alt={'LogoKarlsruhe'} height={60} />
         </div>
       </div>
       <div className="container-lg justify-content-center d-flex">

--- a/src/components/header/LocaleSwitcher.tsx
+++ b/src/components/header/LocaleSwitcher.tsx
@@ -23,19 +23,21 @@ export default function LocaleSwitcher({ className }: { className?: string }) {
   };
 
   return (
-    <select
-      defaultValue={locale}
-      onChange={onLocaleChange}
-      id="locale-switcher"
-      aria-label="locale-switcher"
-      className={`form-select ${className ?? ''}`}
-      style={{ maxWidth: '200px' }}
-    >
-      {[...locales.values()].map((lang) => (
-        <option key={lang} value={lang}>
-          {t('locale', { locale: lang })}
-        </option>
-      ))}
-    </select>
+    <div className={className}>
+      <select
+        defaultValue={locale}
+        onChange={onLocaleChange}
+        id="locale-switcher"
+        aria-label="locale-switcher"
+        className="form-select"
+        style={{ maxWidth: '200px' }}
+      >
+        {[...locales.values()].map((lang) => (
+          <option key={lang} value={lang}>
+            {t('locale', { locale: lang })}
+          </option>
+        ))}
+      </select>
+    </div>
   );
 }

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,18 +1,12 @@
 'use client';
 
-import { Configuration, categoriesSchema } from '@/schemas/configuration-schema';
-
-import ErrorComponent from '../error-handling/ErrorComponent';
+import { Configuration } from '@/schemas/configuration-schema';
 import NavigationContent from './NavigationContent';
 import { Offcanvas } from 'react-bootstrap';
 import { useShowNavigation } from './NavigationProvider';
 
 export default function Navigation({ configuration }: { configuration: Configuration }) {
   const { show, setShow } = useShowNavigation();
-  const categories = categoriesSchema.safeParse(configuration.categories);
-  if (!categories.success) {
-    return <ErrorComponent type="configurationInvalid" error={JSON.stringify(categories.error)} />;
-  }
 
   return (
     <div>
@@ -24,10 +18,14 @@ export default function Navigation({ configuration }: { configuration: Configura
       >
         <Offcanvas.Header closeButton>Open Data Dashboard</Offcanvas.Header>
         <Offcanvas.Body>
-          <NavigationContent categories={configuration.categories} />
+          <NavigationContent categories={configuration.categories} dashboards={configuration.dashboards} />
         </Offcanvas.Body>
       </Offcanvas>
-      <NavigationContent categories={categories.data} className="d-none d-lg-block me-lg-5" />
+      <NavigationContent
+        categories={configuration.categories}
+        dashboards={configuration.dashboards}
+        className="d-none d-lg-block me-lg-5"
+      />
     </div>
   );
 }

--- a/src/components/navigation/NavigationContent.tsx
+++ b/src/components/navigation/NavigationContent.tsx
@@ -1,4 +1,5 @@
-import { Category } from '@/schemas/configuration-schema';
+import { Category, Dashboard } from '@/schemas/configuration-schema';
+
 import { ListGroup } from 'react-bootstrap';
 import { createSharedPathnamesNavigation } from 'next-intl/navigation';
 import { locales } from '@/locales';
@@ -8,14 +9,22 @@ const { Link } = createSharedPathnamesNavigation({
   locales: [...locales.values()],
 });
 
-// TODO: Replace with actual data from configuration
-export default function NavigationContent({ categories, className }: { categories: Category[]; className?: string }) {
+export default function NavigationContent({
+  categories,
+  dashboards: providedDashboards,
+  className,
+}: {
+  categories: Category[];
+  dashboards: Dashboard[];
+  className?: string;
+}) {
   const t = useTranslations('NavigationContent');
+  const [homepage, ...dashboards] = providedDashboards;
   return (
     <ListGroup variant="flush" className={className}>
       <ListGroup.Item className="pe-md-5">
         <Link href="/home" className="nav-link text-nowrap">
-          <i className="bi bi-house-door-fill" /> {t('home')}
+          <i className={`bi bi-${homepage.icon}`} /> {t('home')}
         </Link>
       </ListGroup.Item>
       <ListGroup.Item className="pe-md-5">
@@ -23,21 +32,11 @@ export default function NavigationContent({ categories, className }: { categorie
           <i className="bi bi-bar-chart-fill" /> {t('dashboards')}
         </Link>
         <div className="d-flex flex-column">
-          <Link href="#" className="link-secondary link-underline-opacity-0 m-1 ms-3 text-nowrap">
-            <i className="bi bi-book-half" /> Bevölkerung
-          </Link>
-          <Link href="#" className="link-secondary link-underline-opacity-0 m-1 ms-3 text-nowrap">
-            <i className="bi bi-book-half" /> Verwaltung
-          </Link>
-          <Link href="#" className="link-secondary link-underline-opacity-0 m-1 ms-3 text-nowrap">
-            <i className="bi bi-book-half" /> Bildung
-          </Link>
-          <Link href="#" className="link-secondary link-underline-opacity-0 m-1 ms-3 text-nowrap">
-            <i className="bi bi-book-half" /> Kultur
-          </Link>
-          <Link href="#" className="link-secondary link-underline-opacity-0 m-1 ms-3 text-nowrap">
-            <i className="bi bi-book-half" /> Mobilität
-          </Link>
+          {dashboards.map((dashboard, index) => (
+            <Link key={index} href="#" className="link-secondary link-underline-opacity-0 m-1 ms-3 text-nowrap">
+              <i className={`bi bi-${dashboard.icon}`} /> {dashboard.name}
+            </Link>
+          ))}
         </div>
       </ListGroup.Item>
       <ListGroup.Item className="pe-md-5">

--- a/src/components/resource-details/ResourceDetails.tsx
+++ b/src/components/resource-details/ResourceDetails.tsx
@@ -7,16 +7,16 @@ const ResourceDetailsControls = dynamic(() => import('./ResourceDetailsControls'
 
 export default function ResourceDetails({ resource }: { resource: Resource }) {
   return (
-    <div className="flex-grow-1">
+    <div className="flex-grow-1 p-2" style={{ height: resource.type === 'Embedded' ? '100dvh' : undefined }}>
       <h1 className="h1 text-center">{resource.name}</h1>
       <p className="lead text-center">{resource.description}</p>
       <ResourceDetailsControls resource={resource} />
       <div
         className={`d-flex flex-column flex-grow-1 ${resource.type === 'GeoJSON' ? 'border border-secondary' : ''}`}
-        style={{ height: resource.type === 'GeoJSON' ? '75dvh' : undefined }}
+        style={{ height: resource.type === 'GeoJSON' || resource.type === 'Embedded' ? '75dvh' : undefined }}
       >
         {resource.type === 'Embedded' ? (
-          <EmbeddedViewer resource={resource} height="100%" />
+          <EmbeddedViewer resource={resource} height="100%" className="d-flex h-100" />
         ) : (
           <Visualization resource={resource} />
         )}

--- a/src/components/resource-details/ResourceDetails.tsx
+++ b/src/components/resource-details/ResourceDetails.tsx
@@ -1,5 +1,6 @@
+import { GeoJSONResource, JSONResource, Resource } from '@/schemas/configuration-schema';
+
 import EmbeddedViewer from '../visualization/EmbeddedViewer';
-import { Resource } from '@/schemas/configuration-schema';
 import Visualization from '../visualization/layout/Visualization';
 import dynamic from 'next/dynamic';
 
@@ -7,18 +8,24 @@ const ResourceDetailsControls = dynamic(() => import('./ResourceDetailsControls'
 
 export default function ResourceDetails({ resource }: { resource: Resource }) {
   return (
-    <div className="flex-grow-1 p-2" style={{ height: resource.type === 'Embedded' ? '100dvh' : undefined }}>
+    <div
+      className="flex-grow-1 p-2"
+      style={{ height: resource.type === 'HTML' || resource.type === 'PDF' ? '100dvh' : undefined }}
+    >
       <h1 className="h1 text-center">{resource.name}</h1>
       <p className="lead text-center">{resource.description}</p>
       <ResourceDetailsControls resource={resource} />
       <div
         className={`d-flex flex-column flex-grow-1 ${resource.type === 'GeoJSON' ? 'border border-secondary' : ''}`}
-        style={{ height: resource.type === 'GeoJSON' || resource.type === 'Embedded' ? '75dvh' : undefined }}
+        style={{
+          height:
+            resource.type === 'GeoJSON' || resource.type === 'HTML' || resource.type === 'PDF' ? '75dvh' : undefined,
+        }}
       >
-        {resource.type === 'Embedded' ? (
+        {resource.type === 'HTML' || resource.type === 'PDF' ? (
           <EmbeddedViewer resource={resource} height="100%" className="d-flex h-100" />
         ) : (
-          <Visualization resource={resource} />
+          <Visualization resource={resource as JSONResource | GeoJSONResource} />
         )}
       </div>
     </div>

--- a/src/components/resource-details/ResourceDetailsControls.tsx
+++ b/src/components/resource-details/ResourceDetailsControls.tsx
@@ -111,7 +111,7 @@ export default function ResourceDetailsControls({ resource }: { resource: Resour
             <strong>Code:</strong>
           </div>
           <CopyBlock
-            text={`<iframe width="${iframeWidth}" height="${iframeHeight}" src="${window.location.origin}/${locale}/resource/${resource.id}${keepParams ? getParamsFromWindow() : ''}" frameBorder="0" />`}
+            text={`<iframe width="${iframeWidth}" height="${iframeHeight}" src="${window.location.origin}/${locale}/resource/${resource.id}${keepParams ? getParamsFromWindow() : ''}" />`}
             language="html"
             theme={dracula}
             wrapLongLines={true}

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -36,6 +36,9 @@ export default function Search({
       id="search"
       labelKey="name"
       highlightOnlyResult
+      inputProps={{
+        id: 'search-input',
+      }}
       onInputChange={(term) => {
         search(term, { prefix: true, fuzzy: 0.5, maxFuzzy: 5, combineWith: 'AND' });
       }}

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -16,10 +16,12 @@ const { useRouter } = createSharedPathnamesNavigation({
 
 export default function Search({
   configuration,
+  id,
   className,
   style,
 }: {
   configuration: Configuration;
+  id: string;
   className?: string;
   style?: CSSProperties;
 }) {
@@ -33,11 +35,11 @@ export default function Search({
       className={className}
       style={style}
       filterBy={() => true}
-      id="search"
+      id={id}
       labelKey="name"
       highlightOnlyResult
       inputProps={{
-        id: 'search-input',
+        id: `${id}-input`,
       }}
       onInputChange={(term) => {
         search(term, { prefix: true, fuzzy: 0.5, maxFuzzy: 5, combineWith: 'AND' });

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { CSSProperties, useState } from 'react';
-import { Configuration, GeoJSONResource, JSONResource, Resource } from '@/schemas/configuration-schema';
-import { Highlighter, Typeahead } from 'react-bootstrap-typeahead';
+import { Configuration, Resource } from '@/schemas/configuration-schema';
 
+import SearchResult from './SearchResult';
+import { Typeahead } from 'react-bootstrap-typeahead';
 import { createSharedPathnamesNavigation } from 'next-intl/navigation';
 import { locales } from '@/locales';
 import { useMiniSearch } from 'react-minisearch';
@@ -13,7 +14,6 @@ const { useRouter } = createSharedPathnamesNavigation({
   locales: [...locales.values()],
 });
 
-// eslint-disable-next-line max-lines-per-function
 export default function Search({
   configuration,
   className,
@@ -58,31 +58,7 @@ export default function Search({
       placeholder={t('search')}
       emptyLabel={t('emptyLabel')}
       renderMenuItemChildren={(option, props) => {
-        const resource = option as Resource;
-        const visualizedResource = option as JSONResource | GeoJSONResource;
-        return (
-          <div className="d-flex flex-column text-center text-wrap">
-            <div className="fw-bold">
-              <Highlighter search={props.text}>{resource.name}</Highlighter>
-            </div>
-            <small className="fst-italic">
-              {resource.description && <Highlighter search={props.text}>{resource.description}</Highlighter>}
-            </small>
-            <small>
-              (Id: <Highlighter search={props.text}>{resource.id}</Highlighter>)
-            </small>
-            <div className="my-1">
-              <div className="badge bg-secondary p-2">{resource.type}</div>
-              {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
-              {visualizedResource.visualizations !== undefined &&
-                Object.keys(visualizedResource.visualizations).map((visualization, index) => (
-                  <div key={index} className="badge bg-secondary align-self-start p-2 ms-1">
-                    {visualization.replaceAll(/\b\w/gu, (char) => char.toUpperCase())}
-                  </div>
-                ))}
-            </div>
-          </div>
-        );
+        return <SearchResult resource={option as Resource} menuProps={props} />;
       }}
     />
   );

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -23,7 +23,7 @@ export default function Search({
   className?: string;
   style?: CSSProperties;
 }) {
-  const { search, searchResults } = useMiniSearch(configuration.resources, { fields: ['id', 'name', 'description'] });
+  const { search, searchResults } = useMiniSearch(configuration.resources, { fields: ['name', 'description'] });
   const t = useTranslations('Search');
   const [selected, setSelected] = useState([] as (object | string)[]);
   const router = useRouter();

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -17,9 +17,6 @@ export default function SearchResult({ resource, menuProps }: { resource: Resour
         <small className="fst-italic">
           {resource.description && <Highlighter search={menuProps.text}>{resource.description}</Highlighter>}
         </small>
-        <small>
-          (Id: <Highlighter search={menuProps.text}>{resource.id}</Highlighter>)
-        </small>
         <div className="my-1">
           <div className="badge bg-secondary p-2">{resource.type}</div>
         </div>

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -1,0 +1,29 @@
+// eslint-disable-next-line import/named
+import { Highlighter, TypeaheadMenuProps } from 'react-bootstrap-typeahead';
+
+import { Resource } from '@/schemas/configuration-schema';
+import { getIconForResource } from '@/icons';
+
+export default function SearchResult({ resource, menuProps }: { resource: Resource; menuProps: TypeaheadMenuProps }) {
+  return (
+    <div className="d-flex align-items-center">
+      <div>
+        <i className={`bi bi-${getIconForResource(resource)} fs-1`} />
+      </div>
+      <div className="d-flex flex-column text-center text-wrap flex-fill">
+        <div className="fw-bold">
+          <Highlighter search={menuProps.text}>{resource.name}</Highlighter>
+        </div>
+        <small className="fst-italic">
+          {resource.description && <Highlighter search={menuProps.text}>{resource.description}</Highlighter>}
+        </small>
+        <small>
+          (Id: <Highlighter search={menuProps.text}>{resource.id}</Highlighter>)
+        </small>
+        <div className="my-1">
+          <div className="badge bg-secondary p-2">{resource.type}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/visualization/EmbeddedViewer.tsx
+++ b/src/components/visualization/EmbeddedViewer.tsx
@@ -6,14 +6,16 @@ import useWindowDimensions from '../helper/WindowDimensions';
 export default function EmbeddedViewer({
   resource,
   height: constantHeight,
+  className,
 }: {
   resource: Resource;
   height?: string | number;
+  className?: string;
 }) {
   const { height } = useWindowDimensions();
 
   return (
-    <div className="d-flex h-100">
+    <div className={className}>
       <iframe title={resource.name} src={resource.source} width="100%" height={constantHeight ?? height} />
     </div>
   );

--- a/src/components/visualization/chart-table-filter/ChartTableFilterBody.tsx
+++ b/src/components/visualization/chart-table-filter/ChartTableFilterBody.tsx
@@ -29,7 +29,7 @@ export function ChartTableFilterBody({
           const filterObj = typeof filter === 'object' ? filter : undefined;
           return (
             <fieldset key={key} className="row mb-1 mb-md-3">
-              <legend id={`${resourceId}-${key}-input`} className="col-sm-2 col-form-label">
+              <legend id={`${resourceId}-${key}-input`} className="col-sm-2 col-form-label text-nowrap">
                 {key}
               </legend>
               <div className="col-md-10">

--- a/src/components/visualization/chart-table-filter/ClearableInputGroup.tsx
+++ b/src/components/visualization/chart-table-filter/ClearableInputGroup.tsx
@@ -23,7 +23,7 @@ export function ClearableInputGroup({
   return (
     <div className="input-group">
       <div className="form-floating">
-        <input type={type} id={id} className="form-control" value={value} onChange={onChange} />
+        <input type={type} id={id} className="form-control border-end-0" value={value} onChange={onChange} />
         <label htmlFor={id}>{label}</label>
       </div>
       <button

--- a/src/components/visualization/map/GeoMap.tsx
+++ b/src/components/visualization/map/GeoMap.tsx
@@ -90,7 +90,7 @@ function getIcon(color: string) {
   return L.divIcon({
     className: 'custom-icon-div',
     html: ReactDOMServer.renderToString(
-      <i role="button" aria-label="map-marker" style={{ color, fontSize: '30px' }} className="bi bi-geo-alt-fill" />,
+      <i role="button" aria-label="map-marker" style={{ color }} className="bi bi-geo-alt-fill fs-2" />,
     ),
     iconAnchor: [15, 30],
   });

--- a/src/components/visualization/map/ResetView.tsx
+++ b/src/components/visualization/map/ResetView.tsx
@@ -8,8 +8,8 @@ export default function ResetView({ latLng, zoom }: { latLng: LatLngExpression; 
   const t = useTranslations('ResetView');
   return (
     <button
-      style={{ zIndex: 400, fontSize: '20px' }}
-      className="btn btn-secondary m-3 position-absolute"
+      style={{ zIndex: 400 }}
+      className="btn btn-secondary m-3 position-absolute fs-5"
       onClick={() => {
         map.setView(latLng, zoom);
       }}

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,0 +1,24 @@
+import { JSONResource, Resource } from './schemas/configuration-schema';
+
+export function getIconForResource(resource: Resource) {
+    switch (resource.type) {
+        case 'CSV':
+        case 'JSON': {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+            const visualizedResource = resource as JSONResource;
+            return visualizedResource.visualizations.barChart ? 'bar-chart-fill' : 'table';
+        }
+        case 'GeoJSON': {
+            return 'geo-alt';
+        }
+        case 'HTML': {
+            return 'filetype-html';
+        }
+        case 'PDF': {
+            return 'file-earmark-pdf';
+        }
+        default: {
+            return 'clipboard-data';
+        }
+    }
+}

--- a/src/schemas/configuration-schema.ts
+++ b/src/schemas/configuration-schema.ts
@@ -148,7 +148,7 @@ const dashboardSchema = z
         name: z.string(),
         icon: z.string().default('clipboard-data'),
         description: z.string().optional(),
-        content: z.array(z.union([resourceContentSchema, externalContentSchema])).optional(),
+        contents: z.array(z.union([resourceContentSchema, externalContentSchema])).optional(),
     })
     .strict();
 

--- a/src/schemas/configuration-schema.ts
+++ b/src/schemas/configuration-schema.ts
@@ -127,11 +127,43 @@ export const appearanceSchema = z
     })
     .strict();
 
+const resourceContentSchema = z
+    .object({
+        kind: z.literal('RESOURCE'),
+        id: z.string(),
+        preview: z.boolean(),
+    })
+    .strict();
+
+const externalContentSchema = z
+    .object({
+        kind: z.literal('EXTERNAL'),
+        source: z.string().url(),
+    })
+    .strict();
+
+const dashboardSchema = z
+    .object({
+        id: z.string(),
+        name: z.string(),
+        icon: z.string().default('clipboard-data'),
+        description: z.string().optional(),
+        content: z.array(z.union([resourceContentSchema, externalContentSchema])).optional(),
+    })
+    .strict();
+
+export const dashboardsSchema = z
+    .array(dashboardSchema)
+    .refine((dashboards) => dashboards.some((dashboard) => dashboard.id === 'homepage'), {
+        message: 'The homepage must be configured.',
+    });
+
 export const configurationSchema = z
     .object({
         resources: z.array(resourceSchema),
         appearance: appearanceSchema,
         categories: categoriesSchema,
+        dashboards: dashboardsSchema,
     })
     .strict();
 
@@ -144,3 +176,4 @@ export type Configuration = z.infer<typeof configurationSchema>;
 export type Filter = z.infer<typeof defaultFilterSchema>;
 export type Category = z.infer<typeof categorySchema>;
 export type Appearance = z.infer<typeof appearanceSchema>;
+export type Dashboard = z.infer<typeof dashboardSchema>;

--- a/src/schemas/configuration-schema.ts
+++ b/src/schemas/configuration-schema.ts
@@ -129,7 +129,7 @@ export const appearanceSchema = z
 
 const resourceContentSchema = z
     .object({
-        kind: z.literal('RESOURCE'),
+        type: z.literal('RESOURCE'),
         id: z.string(),
         preview: z.boolean(),
     })
@@ -137,7 +137,8 @@ const resourceContentSchema = z
 
 const externalContentSchema = z
     .object({
-        kind: z.literal('EXTERNAL'),
+        type: z.literal('EXTERNAL'),
+        name: z.string(),
         source: z.string().url(),
     })
     .strict();

--- a/src/schemas/configuration-schema.ts
+++ b/src/schemas/configuration-schema.ts
@@ -11,7 +11,7 @@ const baseResourceSchema = z
 
 export const embeddedResourceSchema = baseResourceSchema
     .extend({
-        type: z.literal('Embedded'),
+        type: z.union([z.literal('HTML'), z.literal('PDF')]),
     })
     .strict();
 


### PR DESCRIPTION
[ODDSK-210](https://h-ka-team-rdqzrlfpomci.atlassian.net/browse/ODDSK-210).

* Homepage
* Configuration for dashboards
* Display dashboard contents (`homepage` is treated as a dashboard)
* Refactor resource type `Embedded` to types `HTML` and `PDF`. For the user, this is hopefully more understandable than `Embedded`. This also allows us the show a `PDF`-specific icon for PDF types
* Enhance search: Show icon fitting the available visualization types in the search results, only search for `name` and `description`. Searching by `id` was not very intuitive and the `id` is an internal parameter primarily anyways

Preview: https://deploy-preview-128--open-data-dashboard.netlify.app/